### PR TITLE
test: fix tests and lock the da version

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,3 @@
 # Primary owner should be listed first in list of global owners, followed by any secondary owners
+
 *       @Aashiq-J @maheshwarishikha

--- a/solutions/standard/version.tf
+++ b/solutions/standard/version.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = ">= 1.75.2"
+      version = "1.75.2"
     }
   }
 }

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -57,17 +57,20 @@ func setupOptions(t *testing.T, prefix string, exampleDir string) *testhelper.Te
 		TerraformDir:  exampleDir,
 		Prefix:        prefix,
 		ResourceGroup: resourceGroup,
-		TerraformVars: map[string]interface{}{
-			"access_tags": permanentResources["accessTags"],
-			"region":      validRegions[rand.Intn(len(validRegions))],
-		},
 	})
+	options.TerraformVars = map[string]interface{}{
+		"access_tags":    permanentResources["accessTags"],
+		"region":         validRegions[rand.Intn(len(validRegions))],
+		"prefix":         options.Prefix,
+		"resource_group": resourceGroup,
+		"resource_tags":  options.Tags,
+	}
 	return options
 }
 
 func TestRunBasicExample(t *testing.T) {
 
-	options := setupOptions(t, "wx-gov", basicExampleDir)
+	options := setupOptions(t, "wxgo-basic", basicExampleDir)
 
 	output, err := options.RunTestConsistency()
 	assert.Nil(t, err, "This should not have errored")
@@ -147,7 +150,7 @@ func TestRunStandardSolution(t *testing.T) {
 		Testing:       t,
 		TerraformDir:  standardSolutionTerraformDir,
 		Region:        validRegions[rand.Intn(len(validRegions))],
-		Prefix:        "governance-st-da",
+		Prefix:        "wxgo-da",
 		ResourceGroup: resourceGroup,
 	})
 
@@ -155,6 +158,8 @@ func TestRunStandardSolution(t *testing.T) {
 		"plan":                "essentials",
 		"resource_group_name": options.Prefix,
 		"provider_visibility": "public",
+		"prefix":              options.Prefix,
+		"region":              options.Region,
 	}
 
 	output, err := options.RunTestConsistency()
@@ -168,7 +173,7 @@ func TestRunStandardUpgradeSolution(t *testing.T) {
 		Testing:       t,
 		TerraformDir:  standardSolutionTerraformDir,
 		Region:        validRegions[rand.Intn(len(validRegions))],
-		Prefix:        "governance-st-da-upg",
+		Prefix:        "wxgo-da-upg",
 		ResourceGroup: resourceGroup,
 	})
 
@@ -176,6 +181,8 @@ func TestRunStandardUpgradeSolution(t *testing.T) {
 		"plan":                "essentials",
 		"resource_group_name": options.Prefix,
 		"provider_visibility": "public",
+		"prefix":              options.Prefix,
+		"region":              options.Region,
 	}
 
 	output, err := options.RunTestUpgrade()


### PR DESCRIPTION
### Description

This PR modifies the prefixes used in tests and locks the DA to 1.75.2 provider version
Issue addressed - [12716](https://github.ibm.com/GoldenEye/issues/issues/12716)

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [x] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
